### PR TITLE
fix total_processed

### DIFF
--- a/preforkserver/manager.py
+++ b/preforkserver/manager.py
@@ -221,7 +221,7 @@ class Manager(object):
             # We have too many spares and need to kill some
             to_kill = spares - self.max_spares
             children = sorted(children,
-                cmp=lambda x, y: cmp(x.totalProcessed, y.totalProcessed),
+                cmp=lambda x, y: cmp(x.total_processed, y.total_processed),
                 reverse=True)
             # Send closes
             for ch in children[:to_kill]:


### PR DESCRIPTION
Hello.

```
get exception: 'ManagerChild' object has no attribute 'totalProcessed'
 traceback: Traceback (most recent call last):
  File "/home/dev/konovalov/beget_msgpack/beget_msgpack/server.py", line 45, in start
    manager.run()
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 314, in run
    self._loop()
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 294, in _loop
    self._assess_state()
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 227, in _assess_state
    reverse=True)
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 226, in <lambda>
    cmp=lambda x, y: cmp(x.totalProcessed, y.totalProcessed),
AttributeError: 'ManagerChild' object has no attribute 'totalProcessed'
```