### PR TITLE
fix_unregister_child

### DIFF
--- a/preforkserver/manager.py
+++ b/preforkserver/manager.py
@@ -164,15 +164,18 @@ class Manager(object):
         completion in a thread.
         """
         fd = child.conn.fileno()
+
+        try:
+            self._poll.unregister(child.conn)
+        except:
+            pass
+
         try:
             child.conn.send([pfe.CLOSE, ''])
             child.close()
         except IOError:
             pass
-        try:
-            self._poll.unregister(child.conn)
-        except:
-            pass
+
         if fd in self._children:
             del self._children[fd]
         if background:


### PR DESCRIPTION
If we close the pipe, we can't get his fd, for poll.unregister.

```
 traceback: Traceback (most recent call last):
  File "/home/dev/konovalov/beget_msgpack/beget_msgpack/server.py", line 45, in start
    manager.run()
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 325, in run
    self._loop()
  File "/home/dev/konovalov/pyportal_new/preforkserver/manager.py", line 292, in _loop
    fd = sock.fileno()
IOError: handle is invalid
```